### PR TITLE
Added boilerplate so that mlangpy can be upload to PyPi. Changed the way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /venv/
 /docs/
 .idea
+
+/build/
+/dist/
+mlangpy.egg-info/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include mlangpy/lark_grammars/*

--- a/mlangpy/lark_grammars/abnf.lark
+++ b/mlangpy/lark_grammars/abnf.lark
@@ -16,10 +16,9 @@
 // Through these amendments to the grammar, we can generate a parse tree
 // that's much easier to use with grammar.py.
 
-// NB: when importing this grammar, the directive %ignore " " must also be
-// used in the instantiation parameter.
-
 %import common.NEWLINE
+%ignore " "
+%ignore NEWLINE
 
 start: syntax
 
@@ -130,7 +129,7 @@ element: rulename | group | option
 repetition: repeat? element
 repeat: specific | variable
 specific: DEC_NUM
-variable: DEC_NUM? _REPEAT DEC_NUM?
+variable: [DEC_NUM] _REPEAT [DEC_NUM]
 
 // Brackets
 option: _START_OPTION alternation _END_OPTION

--- a/mlangpy/lark_grammars/abnf_faithful.lark
+++ b/mlangpy/lark_grammars/abnf_faithful.lark
@@ -13,6 +13,7 @@
 
 %import common.NEWLINE
 
+start: syntax
 syntax: rulelist
 
 // =====================================================================

--- a/mlangpy/lark_grammars/ebnf2.lark
+++ b/mlangpy/lark_grammars/ebnf2.lark
@@ -11,6 +11,8 @@
 
 %import common.LETTER
 %import common.DIGIT
+%ignore NEWLINE
+%ignore " "
 
 // See Part 4 for structure of EBNF rules
 start: syntax

--- a/mlangpy/metaparsers.py
+++ b/mlangpy/metaparsers.py
@@ -6,24 +6,18 @@ from mlangpy.metalanguages.BNF import *
 #from mlangpy.metalanguages.ABNF import *
 
 
-def validate_ABNF(grammar_string):
-    l = Lark(f'''start: syntax
-                %import .lark_grammars.abnf_faithful.syntax
-                %ignore " "
-                %import common.NEWLINE
-                %ignore NEWLINE
-            ''', keep_all_tokens=False)
+def validate_ABNF_faithful(grammar_string):
+    l = Lark.open('./lark_grammars/abnf_faithful.lark', rel_to=__file__)
     p = l.parse(grammar_string)
     return p
 
+def validate_ABNF(grammar_string):
+    l = Lark.open('./lark_grammars/abnf.lark', rel_to=__file__)
+    p = l.parse(grammar_string)
+    return p
 
 def validate_EBNF(grammar_string):
-    l = Lark(f'''start: syntax
-            %import .lark_grammars.ebnf2.syntax
-            %import .common.NEWLINE
-            %ignore NEWLINE+
-            %ignore " "
-        ''')
+    l = Lark.open('./lark_grammars/ebnf2.lark', rel_to=__file__)
     p = l.parse(grammar_string)
     return p
 
@@ -218,8 +212,10 @@ if __name__ == '__main__':
 
     #ebnf = parse_EBNF('../sample_grammars/ebnfs/testing.txt')
 
-    f = open('../sample_grammars/ebnfs/ebnf_self_define_no_comments.txt').read()
-    print(validate_EBNF(f).pretty())
+    f = open('../sample_grammars/abnfs/abnf1.txt').read()
+    print(validate_ABNF(f).pretty())
+    g = open('../sample_grammars/ebnfs/ebnf_self_define_no_comments.txt').read()
+    print(validate_EBNF(g).pretty())
 
 
 

--- a/sample_grammars/abnfs/abnf1.txt
+++ b/sample_grammars/abnfs/abnf1.txt
@@ -1,3 +1,3 @@
 comment =  ";" *(WSP / VCHAR) CRLF
-repeat = 1*DIGIT / (*DIGIT "*" *DIGIT)
+repeat = 1*2DIGIT / (*DIGIT "*" *DIGIT)
 char-val =  DQUOTE *(%x20-21 / %x23-7E) DQUOTE

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="mlangpy",
+    version="0.0.5",
+    author="Jamie Muir",
+    author_email="jam10@hw.ac.uk",
+    description="A package for parsing and manipulating some standard metalanguages.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/rium9/mlangpy",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.6',
+    include_package_data=True
+)


### PR DESCRIPTION
that grammar files are loaded into metaparsers.py (using Lark.open now - should have been using this from the start). MANIFEST.in is required so that lark_grammars are included in the package.