### PR TITLE
Added classes for all ABNF features outlined in RFC 5234. Ready to be…

### DIFF
--- a/mlangpy/grammar.py
+++ b/mlangpy/grammar.py
@@ -404,11 +404,14 @@ class Ruleset:
     """
 
     def __init__(self, rules):
+        if not (issubclass(rules.__class__, list) or isinstance(rules, OrderedSet)):
+            raise GrammarException('A Ruleset requires a list-like object as its rules argument.')
 
         if isinstance(rules, list):
             self.rules = OrderedSet(rules)
         else:
             self.rules = rules
+
 
     def load_rules(self, rules):
         """ Load in a list of Rule objects.
@@ -531,7 +534,7 @@ class Metalanguage:
         syntax (dict):      A number of syntax settings.
     """
 
-    def __init__(self, ruleset, syntax_dict=None, normalise=True):
+    def __init__(self, ruleset, syntax_dict=None, normalise=False):
         """ Initialise a metalanguage with a ruleset and optionally a syntax dictionary. The syntax dictionary
         may be customised to change the form of specific features, e.g. to comply with a specification such
         as EBNF, ABNF or RBNF.

--- a/mlangpy/lark_grammars/abnf.lark
+++ b/mlangpy/lark_grammars/abnf.lark
@@ -102,8 +102,9 @@ bin_range: BIN_NUM _NUM_RANGE BIN_NUM
 // =====================================================================
 //       Part 3: Defining the abstract syntax of ABNF
 // =====================================================================
-syntax: (rule | c_nl)+
-rule: rulename (inc_defined_as | defined_as) elements c_nl
+syntax: (rule | inc_rule | c_nl)+
+rule: rulename (_DEF_SYM c_nl*) elements c_nl
+inc_rule: rulename (_INCDEF_SYM c_nl*) elements c_nl
 
 // Commenting/formatting
 c_nl: comment | NEWLINE
@@ -115,7 +116,7 @@ RULE_STR: ALPHA (ALPHA | DIGIT | "-")*
 rulename: RULE_STR
 
 // Definition symbols
-inc_defined_as: _INCDEF_SYM
+inc_defined_as: _INCDEF_SYM c_nl*
 defined_as: _DEF_SYM c_nl*
 
 // RHS of rules

--- a/mlangpy/metalanguages/ABNF.py
+++ b/mlangpy/metalanguages/ABNF.py
@@ -1,9 +1,24 @@
 from ..grammar import *
 
+# We don't need to define new classes for Concat, Group or Optional - the syntax is the same.
+
+
 class ABNFDefList(DefList):
 
     def __init__(self, terms, separator='/'):
         super().__init__(terms, separator=separator)
+
+
+class ABNFRule(Rule):
+
+    def __init__(self, left, right, production='=', terminator=''):
+        super().__init__(left, right, production=production, terminator=terminator)
+
+
+class ABNFIncRule(Rule):
+
+    def __init__(self, left, right, production='=/', terminator=''):
+        super().__init__(left, right, production=production, terminator=terminator)
 
 
 class ABNFTerminal(Terminal):
@@ -19,15 +34,17 @@ class ABNFNonTerminal(NonTerminal):
 
 
 class ABNFRepetition(TernaryOperator):
-
-    def __init__(self, left, middle, right, compact=True, operator1_sym='*', operator2_sym=''):
+    """ Model ABNF specific and variable repetition in one - this is possible because specific repetition
+        is just a special case of variable repetition.
+    """
+    def __init__(self, subject, left='', right='', compact=True, operator1_sym='*', operator2_sym=''):
         if not (isinstance(left, int) or left == ''):
             raise GrammarException(f'{self.__class__.__name__} requires an integer or \'\' as its left argument.')
-        if not (isinstance(middle, int) or middle == ''):
-            raise GrammarException(f'{self.__class__.__name__} requires an integer or \'\' as its middle argument.')
-        if not issubclass(right.__class__, Feature):
-            raise GrammarException(f'{self.__class__.__name__} requires a Feature as its right argument.')
-        super().__init__(left, middle, right, operator1_sym, operator2_sym)
+        if not (isinstance(right, int) or right == ''):
+            raise GrammarException(f'{self.__class__.__name__} requires an integer or \'\' as its right argument.')
+        if not issubclass(subject.__class__, Feature):
+            raise GrammarException(f'{self.__class__.__name__} requires a Feature as its subject argument.')
+        super().__init__(left, right, subject, operator1_sym, operator2_sym)
         self.compact = compact
 
     def __str__(self):
@@ -44,7 +61,7 @@ class ABNFChar(Terminal):
         self.char_sym = char_sym
         if not isinstance(subject, int):
             raise GrammarException(f'{self.__class__.__name__} must have an integer as the subject.')
-        super().__init__(subject, left_bound=left_bound, right_bound=right_bound)
+        super().__init__(str(subject), left_bound=left_bound, right_bound=right_bound)
 
     def __str__(self):
         return f'{self.left_bound}{self.char_sym}{self.denom}{self.subject}{self.right_bound}'
@@ -63,8 +80,16 @@ class ABNFCharRange(BinaryOperator):
         return f'{self.left}{self.operator_sym}{self.right.subject}'
 
 
+# Will this being a Sequence cause equality issues?
 class ABNFCharConcat(Sequence):
     pass
+
+
+class ABNFComment(Symbol):
+
+    def __init__(self, subject, left_bound=';', right_bound='\n'):
+        super().__init__(subject, left_bound, right_bound)
+
 
 class ABNF(Metalanguage):
 
@@ -72,5 +97,12 @@ class ABNF(Metalanguage):
         super().__init__(ruleset, syntax_dict={
             Concat: Concat,
             DefList: ABNFDefList,
-            Rule: Rule
-        })
+            Rule: Rule,
+            Terminal: ABNFTerminal,
+            NonTerminal: ABNFNonTerminal,
+
+            # Auxiliary
+            Optional: Optional,
+            Group: Group,
+            Repetition: ABNFRepetition,
+        }, normalise=normalise)

--- a/mlangpy/metaparsers.py
+++ b/mlangpy/metaparsers.py
@@ -104,9 +104,10 @@ class BuildEBNF(Transformer):
 
 
 class BuildABNF(Transformer):
+    """ Generate a metalanguages.ABNF.ABNF instance from a parse tree built using abnf.lark. """
 
     def start(self, args):
-        return ABNF
+        return ABNF(args[0])
 
 
 class BuildRBNF(Transformer):
@@ -216,16 +217,16 @@ if __name__ == '__main__':
 
     f = open('../sample_grammars/abnfs/abnf1.txt').read()
     print(validate_ABNF(f).pretty())
+    p = validate_ABNF(f)
+    print(p)
+    abnf = BuildABNF().transform(p)
+    print(abnf.ruleset)
 
     a = ABNFChar('d', 100)
     b = ABNFChar('d', 110)
     x = ABNFTerminal('hello')
     c = ABNFCharRange(a, b)
-    d = ABNFRepetition(1, '', x)
+    d = ABNFRepetition(x, left=0, right=1)
     print(d)
     print(c)
-
-
-
-
 

--- a/sample_grammars/abnfs/abnf1.txt
+++ b/sample_grammars/abnfs/abnf1.txt
@@ -1,3 +1,5 @@
 comment =  ";" *(WSP / VCHAR) CRLF
-repeat = 1*2DIGIT / (*DIGIT "*" *DIGIT)
+repeat = ;hi
+    1*2DIGIT / (*DIGIT "*" *DIGIT)
 char-val =  DQUOTE *(%x20-21 / %x23-7E) DQUOTE
+repeat =/ "hi"


### PR DESCRIPTION
… used

to build ABNF features from a grammar using abnf.lark, but first need to
clean up grammar.py - specifically, resolve issues with OrderedSets: either
replace them with lists, OR implement __hash__ for Rules, which will
likely require implementing __hash__ for all other classes.